### PR TITLE
component: If text_field hint text is empty, do not display a space

### DIFF
--- a/component/text_field.go
+++ b/component/text_field.go
@@ -192,8 +192,8 @@ func (in *TextField) Update(gtx C, th *material.Theme, hint string) {
 		spacing = 4
 	}
 	in.label.Smallest = layout.Inset{
-		Left:  unit.Dp(spacing),
-		Right: unit.Dp(spacing),
+		Left:  spacing,
+		Right: spacing,
 	}.Layout(gtx, func(gtx C) D {
 		return material.Label(th, textSmall, hint).Layout(gtx)
 	})

--- a/component/text_field.go
+++ b/component/text_field.go
@@ -187,9 +187,13 @@ func (in *TextField) Update(gtx C, th *material.Theme, hint string) {
 	// Hack: Reset min constraint to 0 to avoid min == max.
 	gtx.Constraints.Min.X = 0
 	macro := op.Record(gtx.Ops)
+	var spacing unit.Dp
+	if len(hint) > 0 {
+		spacing = 4
+	}
 	in.label.Smallest = layout.Inset{
-		Left:  unit.Dp(4),
-		Right: unit.Dp(4),
+		Left:  unit.Dp(spacing),
+		Right: unit.Dp(spacing),
 	}.Layout(gtx, func(gtx C) D {
 		return material.Label(th, textSmall, hint).Layout(gtx)
 	})


### PR DESCRIPTION
Currently, if an empty hint text is used for a text_field, a small space is shown in the field border. This pull request removes the space, so that a simple text field with border is shown if hint is not set.